### PR TITLE
fix(cli): ValueError prints help for api-key

### DIFF
--- a/shell_craft/cli/key.py
+++ b/shell_craft/cli/key.py
@@ -91,5 +91,10 @@ def add_arguments(parser: ArgumentParser):
         help="The OpenAI API key to use.",
     )
 
-    if not parser.parse_known_args()[0].api_key:
-        parser.set_defaults(api_key=get_api_key())
+    try:
+        if not parser.parse_known_args()[0].api_key:
+            parser.set_defaults(api_key=get_api_key())
+    except ValueError:
+        print("No API key found. Please provide one with the --api-key argument.")
+        parser.print_help()
+        exit(1)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/user/Desktop/Workspace/shell_craft/__main__.py", line 21, in <module>
    from shell_craft.cli import main
  File "/home/user/Desktop/Workspace/shell_craft/cli/__init__.py", line 21, in <module>
    from .main import main
  File "/home/user/Desktop/Workspace/shell_craft/cli/main.py", line 24, in <module>
    from .parser import PARSER, get_arguments
  File "/home/user/Desktop/Workspace/shell_craft/cli/parser.py", line 177, in <module>
    PARSER = initialize_parser(
  File "/home/user/Desktop/Workspace/shell_craft/cli/parser.py", line 148, in initialize_parser
    _add_args_parser(parser, module, KNOWN_ARGS)
  File "/home/user/Desktop/Workspace/shell_craft/cli/parser.py", line 89, in _add_args_parser
    module.add_arguments(parser)
  File "/home/user/Desktop/Workspace/shell_craft/cli/key.py", line 98, in add_arguments
    raise ArgumentError(None, "No API key found")
argparse.ArgumentError: No API key found
```

Fixes #52 -- API-Key when not defined will alert, and explain that the api-key is required and print the help.