### PR TITLE
Limit --model

### DIFF
--- a/shell_craft/cli/main.py
+++ b/shell_craft/cli/main.py
@@ -18,10 +18,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+from argparse import ArgumentParser
+
 from shell_craft import Service
 from shell_craft.factories import PromptFactory
 
-from .parser import PARSER, get_arguments
+from .parser import get_arguments, initialize_parser
 
 
 def main():
@@ -29,7 +31,15 @@ def main():
     Main function that processes the command-line arguments and queries the
     OpenAI API using shell_craft.
     """
-    args = get_arguments(PARSER)
+    args = get_arguments(
+        initialize_parser(
+            ArgumentParser(
+                prog="shell-craft",
+                description="Generating shell commands and code using natural language models (OpenAI ChatGPT).",
+                add_help=False
+            )
+        )
+    )
     prompt = PromptFactory.get_prompt(args.prompt)
 
     if getattr(args, "refactor", False):

--- a/shell_craft/cli/models.py
+++ b/shell_craft/cli/models.py
@@ -37,4 +37,12 @@ def add_arguments(parser: ArgumentParser):
         type=str,
         default="gpt-3.5-turbo",
         help="The input to prompt the API with.",
+        choices=[
+            "gpt-4",
+            "gpt-4-0314",
+            "gpt-4-32k",
+            "gpt-4-32k-0314",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-0301",
+        ]
     )

--- a/shell_craft/cli/parser.py
+++ b/shell_craft/cli/parser.py
@@ -174,16 +174,7 @@ def get_arguments(parser: ArgumentParser) -> Namespace:
 
     return parser.parse_args(arguments)
 
-PARSER = initialize_parser(
-    ArgumentParser(
-        prog="shell-craft",
-        description="Generating shell commands and code using natural language models (OpenAI ChatGPT).",
-        add_help=False
-    )
-)
-
 __all__ = [
     "get_arguments",
-    "PARSER"
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Johnathan P. Irvin and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+from argparse import ArgumentParser
+
+from shell_craft.cli.models import add_arguments as add_model_arguments
+from pytest import mark
+
+@mark.parametrize('model', [
+    'gpt-4',
+    'gpt-4-0314',
+    'gpt-4-32k',
+    'gpt-4-32k-0314',
+    'gpt-3.5-turbo',
+    'gpt-3.5-turbo-0301',
+])
+def test_ai_model_arguments(model: str):
+    parser = ArgumentParser()
+    add_model_arguments(parser)
+    args = parser.parse_args(['--model', model])
+    assert args.model == model


### PR DESCRIPTION
Closes #44 -- Limits `--model` to choices.

```
$ python -m shell_craft --model badmodel List files

<snipped>
shell-craft: error: argument --model: invalid choice: 'badmodel' (choose from 'gpt-4', 'gpt-4-0314', 'gpt-4-32k', 'gpt-4-32k-0314', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0301')
```