### PR TITLE
Auto-Fill Github Issue Urls

### DIFF
--- a/shell_craft/cli/github.py
+++ b/shell_craft/cli/github.py
@@ -20,16 +20,26 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from argparse import ArgumentParser
 
+from shell_craft.prompts import PromptFactory
+from shell_craft.prompts.templates import (BUG_REPORT_PROMPT,
+                                           FEATURE_REQUEST_PROMPT)
+
+
+ARGUMENTS = {
+    'prompt': lambda x: PromptFactory.get_prompt(x) in [ BUG_REPORT_PROMPT, FEATURE_REQUEST_PROMPT ]
+}
+
 def add_arguments(parser: ArgumentParser):
     """
-    Adds '-h' and '--help' arguments to the parser. These arguments are used to
-    display the help message for the program.
+    Adds 'github' argument to the parser. This argument is used to
+    specify the URL to the GitHub repository to open an issue or feature
+    request for.
 
     Args:
         parser (ArgumentParser): The parser to add the argument to.
-    """    
+    """
     parser.add_argument(
-        "-h --help",
-        action="help",
-        help="Show this help message and exit."
+        '--github',
+        type=str,
+        help='The URL to the GitHub repository to open an issue or feature request for.'
     )

--- a/shell_craft/cli/language.py
+++ b/shell_craft/cli/language.py
@@ -34,7 +34,7 @@ def add_arguments(parser: ArgumentParser):
 
     Args:
         parser (ArgumentParser): The parser to add the argument to.
-    """    
+    """
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument(
         '--refactor',

--- a/shell_craft/cli/main.py
+++ b/shell_craft/cli/main.py
@@ -22,8 +22,29 @@ from argparse import ArgumentParser
 
 from shell_craft import Service
 from shell_craft.factories import PromptFactory
+from shell_craft.cli.github import GitHubArguments
 
 from .parser import get_arguments, initialize_parser
+
+def get_github_url_or_error(prompt: str, repository: str) -> str:
+    """
+    Returns the GitHub URL for the prompt.
+
+    Args:
+        prompt (str): The prompt to generate the GitHub URL for.
+        repository (str): The GitHub URL to generate the URL for.
+
+    Returns:
+        str: The GitHub URL for the prompt.
+    """
+    try:
+        return GitHubArguments.from_prompt(
+            prompt
+        ).as_url(
+            repository
+        )
+    except Exception:
+        return "Error: Unable to generate GitHub URL."
 
 
 def main():
@@ -61,8 +82,16 @@ def main():
         )
     )
 
+    github_url = getattr(args, "github", None)
     if isinstance(result, list):
         for _, r in enumerate(result):
-            print(r)
+            if github_url:
+                print(get_github_url_or_error(r, github_url))
+            else:
+                print(r)
+        exit(0)
+
+    if github_url:
+        print(get_github_url_or_error(result, github_url))
     else:
         print(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,8 +19,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from argparse import ArgumentParser
+from typing import Union
 
-from pytest import fixture, mark
+from pytest import mark
 
 from shell_craft.cli.github import GitHubArguments
 from shell_craft.cli.github import add_arguments as add_github_arguments
@@ -52,7 +53,7 @@ def test_github_arguments():
     ('labels', ['one', 'two', 'three']),
     ('body', 'about me\n\nbody'),
 ])
-def test_github_arguments_from_prompt(field: str, value: list[str] | str):
+def test_github_arguments_from_prompt(field: str, value: Union[list[str], str]):
     args = GitHubArguments.from_prompt("""
 ---
 name: test


### PR DESCRIPTION
Closes #56 

Example:

```bash
shell-craft --prompt feature_request --github https://github.com/JohnnyIrvin/Python-Template When the okay button is clicked display a confirm popup
```

Returns

https://github.com/JohnnyIrvin/Python-Template/issues/new?title=Add+Confirm+Popup+to+Okay+Button+Click&labels=Enhancement&body=This+feature+request+adds+a+confirm+popup+to+the+okay+button+click+event%0A%0A%2A%2AIs+your+feature+request+related+to+a+problem%3F+Please+describe.%2A%2A%0ASometimes+users+mistakenly+click+the+okay+button+on+a+form+or+a+website+causing+unintended+consequences.+Adding+a+confirm+popup+would+prevent+these+mistakes.%0A%0A%2A%2ADescribe+the+solution+you%27d+like%2A%2A%0AWhen+the+user+clicks+the+okay+button%2C+a+confirm+popup+should+appear+asking+%22Are+you+sure+you+want+to+proceed%3F%22.+If+the+user+clicks+%22Cancel%22+in+the+confirm+popup%2C+the+original+action+should+be+canceled.+If+the+user+clicks+%22Okay%22%2C+the+original+action+should+proceed+as+normal.%0A%0A%2A%2ADescribe+alternatives+you%27ve+considered%2A%2A%0AThe+main+alternative+is+not+adding+the+confirm+popup.+Another+option+is+to+add+an+undo+functionality+so+that+the+user+can+undo+the+previous+action+in+case+of+a+mistake.+However%2C+this+adds+complexity+and+may+not+be+applicable+in+all+scenarios.
